### PR TITLE
Custom subscription swap method

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Auth;
 use Laravel\Spark\Subscriptions\Plan;
 use Laravel\Spark\Events\User\Registered;
 use Laravel\Spark\Events\User\Subscribed;
+use Laravel\Spark\InteractsWithSparkHooks;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Auth\ThrottlesLogins;
 use Illuminate\Foundation\Validation\ValidatesRequests;
@@ -25,7 +26,7 @@ use Laravel\Spark\Contracts\Auth\Subscriber as SubscriberContract;
 
 class AuthController extends Controller
 {
-    use AuthenticatesAndRegistersUsers, ThrottlesLogins, ValidatesRequests;
+    use AuthenticatesAndRegistersUsers, ThrottlesLogins, ValidatesRequests, InteractsWithSparkHooks;
 
     /**
      * The user repository instance.
@@ -226,9 +227,9 @@ class AuthController extends Controller
      */
     protected function validateRegistration(Request $request, $withSubscription = false)
     {
-        if (Spark::$validateProfileUpdatesWith) {
+        if (Spark::$validateRegistrationsWith) {
             $this->callCustomValidator(
-                Spark::$validateProfileUpdatesWith, $request, [$withSubscription]
+                Spark::$validateRegistrationsWith, $request, [$withSubscription]
             );
         } else {
             $this->validateDefaultRegistration($request, $withSubscription);

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -49,7 +49,7 @@ class SecurityController extends Controller
     {
         $this->validate($request, [
             'old_password' => 'required',
-            'password' => 'required|confirmed|max:6',
+            'password' => 'required|confirmed|min:6',
         ]);
 
         if (! Hash::check($request->old_password, Auth::user()->password)) {

--- a/app/Http/Controllers/Settings/SubscriptionController.php
+++ b/app/Http/Controllers/Settings/SubscriptionController.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Spark\Events\User\Subscribed;
 use Illuminate\Support\Facades\Validator;
+use Laravel\Spark\InteractsWithSparkHooks;
 use Illuminate\View\Expression as ViewExpression;
 use Laravel\Spark\Events\User\SubscriptionResumed;
 use Laravel\Spark\Events\User\SubscriptionCancelled;
@@ -19,7 +20,7 @@ use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 
 class SubscriptionController extends Controller
 {
-	use ValidatesRequests;
+	use InteractsWithSparkHooks, ValidatesRequests;
 
     /**
      * The user repository instance.
@@ -87,6 +88,8 @@ class SubscriptionController extends Controller
 
         if ($plan->price() === 0) {
             $this->cancelSubscription();
+        } elseif (Spark::$swapSubscriptionsWith) {
+            $this->callCustomUpdater(Spark::$swapSubscriptionsWith, $request, [Auth::user()]);
         } else {
             Auth::user()->subscription($request->plan)
                     ->maintainTrial()->prorate()->swapAndInvoice();

--- a/app/InteractsWithSparkHooks.php
+++ b/app/InteractsWithSparkHooks.php
@@ -24,7 +24,7 @@ trait InteractsWithSparkHooks
             $callback = [app($class), $method];
         }
 
-        $validator = call_user_func($callback, array_merge([$request], $arguments));
+        $validator = call_user_func_array($callback, array_merge([$request], $arguments));
 
         $validator = $validator instanceof ValidatorContract
                         ? $validator

--- a/app/Services/Auth/TwoFactor/Authy.php
+++ b/app/Services/Auth/TwoFactor/Authy.php
@@ -34,7 +34,7 @@ class Authy implements Provider
             'form_params' => [
                 'user' => [
                     'email' => $user->getEmailForTwoFactorAuth(),
-                    'cellphone' => str_replace(['-', '.'], '', $user->getAuthPhoneNumber()),
+                    'cellphone' => str_replace(['-', '.', ' '], '', $user->getAuthPhoneNumber()),
                     'country_code' => $user->getAuthCountryCode(),
                 ],
             ],

--- a/app/Services/Auth/TwoFactor/Authy.php
+++ b/app/Services/Auth/TwoFactor/Authy.php
@@ -34,7 +34,7 @@ class Authy implements Provider
             'form_params' => [
                 'user' => [
                     'email' => $user->getEmailForTwoFactorAuth(),
-                    'cellphone' => str_replace(['-', '.', ' '], '', $user->getAuthPhoneNumber()),
+                    'cellphone' => preg_replace('/[^0-9]/', '', $user->getAuthPhoneNumber()),
                     'country_code' => $user->getAuthCountryCode(),
                 ],
             ],

--- a/app/Spark.php
+++ b/app/Spark.php
@@ -60,6 +60,13 @@ class Spark
     public static $createUsersWith;
 
     /**
+     * The callback used to move a user to another plan.
+     *
+     * @var callable|null
+     */
+    public static $swapSubscriptionsWith;
+
+    /**
      * Indicates if two-factor authentication is supported.
      *
      * @var bool
@@ -345,6 +352,17 @@ class Spark
     public static function createUsersWith($callback)
     {
         static::$createUsersWith = $callback;
+    }
+
+    /**
+     * Set a callback to be used when moving the user to another plan.
+     *
+     * @param  callable|string  $callback
+     * @return void
+     */
+    public static function swapSubscriptionsWith($callback)
+    {
+        static::$swapSubscriptionsWith = $callback;
     }
 
     /**

--- a/app/Subscriptions/Coupon.php
+++ b/app/Subscriptions/Coupon.php
@@ -60,7 +60,6 @@ class Coupon implements JsonSerializable
      * Create a new coupon instance.
      *
      * @param  string  $id
-     * @param  string  $name
      * @return void
      */
     public function __construct($id)

--- a/app/Subscriptions/Plan.php
+++ b/app/Subscriptions/Plan.php
@@ -158,7 +158,7 @@ class Plan implements JsonSerializable
     /**
      * Set the currency symbol used by the plan.
      *
-     * @param  string  $symbol
+     * @param  string  $currencySymbol
      * @return $this|string
      */
     public function currencySymbol($currencySymbol)
@@ -185,7 +185,7 @@ class Plan implements JsonSerializable
     /**
      * Specify the number of trial days the plan receives.
      *
-     * @param  int  $days
+     * @param  int  $trialDays
      * @return $this
      */
     public function trialDays($trialDays = null)

--- a/app/Ux/Settings/DashboardTabs.php
+++ b/app/Ux/Settings/DashboardTabs.php
@@ -41,7 +41,7 @@ class DashboardTabs extends Tabs
     /**
      * Get the tab configuration for the "subscription" tab.
      *
-     * @return \Laravel\Spark\Ux\Settings\Tab|null
+     * @return \Laravel\Spark\Ux\Settings\Tab|void
      */
     public function subscription($force = false)
     {

--- a/app/Ux/Settings/DashboardTabs.php
+++ b/app/Ux/Settings/DashboardTabs.php
@@ -41,7 +41,7 @@ class DashboardTabs extends Tabs
     /**
      * Get the tab configuration for the "subscription" tab.
      *
-     * @return \Laravel\Spark\Ux\Settings\Tab|void
+     * @return \Laravel\Spark\Ux\Settings\Tab|null
      */
     public function subscription($force = false)
     {

--- a/resources/views/layouts/common/head.blade.php
+++ b/resources/views/layouts/common/head.blade.php
@@ -5,8 +5,8 @@
 <title>Laravel</title>
 
 <!-- Fonts -->
-<link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css" rel='stylesheet' type='text/css'>
-<link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700" rel='stylesheet' type='text/css'>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css" rel='stylesheet' type='text/css'>
+<link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700" rel='stylesheet' type='text/css'>
 
 <!-- Styles -->
 <link href="{{ asset('/css/app.css') }}" rel="stylesheet">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -9,7 +9,7 @@
 
     <!-- Fonts -->
     <link href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Lato:100,300,400,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:100,300,400,700' rel='stylesheet' type='text/css'>
 
     <!-- Styles -->
     <link href="{{ asset('/css/app.css') }}" rel="stylesheet">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -8,7 +8,7 @@
     <title>Laravel</title>
 
     <!-- Fonts -->
-    <link href='//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
+    <link href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
     <link href='http://fonts.googleapis.com/css?family=Lato:100,300,400,700' rel='stylesheet' type='text/css'>
 
     <!-- Styles -->


### PR DESCRIPTION
This introduces a new `Spark::$swapSubscriptionsWith` callback that can be used when a user switches their plan, rather than Cashier’s built-in.
